### PR TITLE
OpenSemba | Make WireBase parent class and use it in Extremes

### DIFF
--- a/src/core/physicalModel/CMakeLists.txt
+++ b/src/core/physicalModel/CMakeLists.txt
@@ -23,5 +23,6 @@ add_library(opensemba_core_physicalmodel STATIC
     "wire/Extremes.cpp"
     "wire/MultiWire.cpp"
     "wire/Wire.cpp"
+    "wire/WireBase.cpp"
 )
 target_link_libraries(opensemba_core_physicalmodel opensemba_core_math)

--- a/src/core/physicalModel/wire/Extremes.cpp
+++ b/src/core/physicalModel/wire/Extremes.cpp
@@ -5,13 +5,15 @@ namespace physicalModel {
 namespace wire {
 
 Extremes::Extremes(const std::string& name,
-                   const Wire& wire,
+                   const WireBase* wire,
                    const multiport::Multiport* extremeL,
                    const multiport::Multiport* extremeR)
-:   Wire(wire)
 {
     setName(name);
-    setId(wire.getId());
+    setId(wire->getId());
+
+    wire_.reset(wire->clone().release()->castTo<WireBase>());
+    
     if (extremeL != nullptr) {
         extreme_[0].reset(extremeL->clone().release()->castTo<multiport::Multiport>());
     }
@@ -22,9 +24,10 @@ Extremes::Extremes(const std::string& name,
 
 Extremes::Extremes(const Extremes& rhs) : 
     Identifiable<Id>(rhs),
-    PhysicalModel(rhs),
-    Wire(rhs)
+    PhysicalModel(rhs)
 {
+    wire_.reset(rhs.wire_->clone().release()->castTo<WireBase>());
+
     if (rhs.extreme_[0] != nullptr) {
         extreme_[0].reset(rhs.extreme_[0]->clone().release()->castTo<multiport::Multiport>());
     }

--- a/src/core/physicalModel/wire/Extremes.h
+++ b/src/core/physicalModel/wire/Extremes.h
@@ -1,16 +1,17 @@
 #pragma once
 
 #include "Wire.h"
+#include "MultiWire.h"
 #include "core/physicalModel/multiport/Multiport.h"
 
 namespace semba {
 namespace physicalModel {
 namespace wire {
 
-class Extremes : public virtual Wire  {
+class Extremes : public WireBase  {
 public:
     Extremes(const std::string&,
-             const Wire& wire,
+             const WireBase* wire,
              const multiport::Multiport* extremeL,
              const multiport::Multiport* extremeR);
     Extremes(const Extremes& rhs);
@@ -18,6 +19,10 @@ public:
 
     virtual std::unique_ptr<PhysicalModel> clone() const override {
         return std::make_unique<Extremes>(*this);
+    }
+
+    const WireBase* getWire() const {
+        return wire_.get();
     }
 
     const multiport::Multiport *getExtreme(const std::size_t i) const {
@@ -30,6 +35,7 @@ public:
 private:
     // TODO: Remove plain array, maybe GroupIdentifiableUnique / Physical Model Group?
     std::unique_ptr<const multiport::Multiport> extreme_[2];
+    std::unique_ptr<WireBase> wire_;
 };
 
 }

--- a/src/core/physicalModel/wire/MultiWire.h
+++ b/src/core/physicalModel/wire/MultiWire.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "core/physicalModel/PhysicalModel.h"
+#include "WireBase.h"
 #include <vector>
 
 namespace semba::physicalModel::wire {
-class MultiWire : public virtual PhysicalModel {
+class MultiWire : public WireBase {
 public:
     MultiWire(
         const Id id,

--- a/src/core/physicalModel/wire/Wire.h
+++ b/src/core/physicalModel/wire/Wire.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "core/physicalModel/PhysicalModel.h"
+#include "core/physicalModel/wire/WireBase.h"
 
 namespace semba {
 namespace physicalModel {
 namespace wire {
 
-class Wire : public virtual PhysicalModel {
+class Wire : public WireBase {
 public:
     Wire(const Id id,
          const std::string name,

--- a/src/core/physicalModel/wire/WireBase.cpp
+++ b/src/core/physicalModel/wire/WireBase.cpp
@@ -1,0 +1,18 @@
+#include "WireBase.h"
+
+namespace semba {
+namespace physicalModel {
+namespace wire {
+
+WireBase::WireBase(const Id id,
+           const std::string name)
+{
+}
+
+WireBase::WireBase(const WireBase& rhs)
+{
+}
+
+}
+} 
+} 

--- a/src/core/physicalModel/wire/WireBase.h
+++ b/src/core/physicalModel/wire/WireBase.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "core/physicalModel/PhysicalModel.h"
+
+namespace semba {
+namespace physicalModel {
+namespace wire {
+
+class WireBase : public virtual PhysicalModel {
+protected:
+    WireBase() = default;
+    WireBase(const Id id,
+         const std::string name);
+    
+    WireBase(const WireBase&);
+public:
+    virtual ~WireBase() = default;
+
+};
+
+}
+} 
+} 
+

--- a/test/core/physicalModel/wire/ExtremesTest.cpp
+++ b/test/core/physicalModel/wire/ExtremesTest.cpp
@@ -19,10 +19,14 @@ TEST_F(ExtremesTest, build_from_wire_and_multiport)
     multiport::Predefined mp1(Id(3), "short", multiport::Multiport::Type::shortCircuit);
     multiport::Predefined mp2(Id(4), "open", multiport::Multiport::Type::openCircuit);
     
-    wire::Extremes extremes("extremes", wire, &mp1, &mp2);
+    wire::Extremes extremes("extremes", &wire, &mp1, &mp2);
 
     EXPECT_EQ(Id(2), extremes.getId());
     EXPECT_EQ("extremes", extremes.getName()); 
+
+    EXPECT_EQ(wire.getRadius(), extremes.getWire()->castTo<wire::Wire>()->getRadius());
+    EXPECT_EQ(wire.getSeriesResistance(), extremes.getWire()->castTo<wire::Wire>()->getSeriesResistance());
+    EXPECT_EQ(wire.getSeriesInductance(), extremes.getWire()->castTo<wire::Wire>()->getSeriesInductance());
 
     EXPECT_EQ(mp1.getType(), extremes.getExtreme(0)->getType());
     EXPECT_EQ(mp2.getType(), extremes.getExtreme(1)->getType());


### PR DESCRIPTION
Changes needed to Wire physical models so different kinds of wires can be used in extremes.