### PR TITLE
Core | Make VTK Files have their Probe type in their names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 .vs/
 .vscode/
 CMakeSettings.json
+/test/exporters/resultFiles/*

--- a/src/core/outputRequest/BulkCurrent.cpp
+++ b/src/core/outputRequest/BulkCurrent.cpp
@@ -24,5 +24,12 @@ math::UInt BulkCurrent::getSkip() const {
     return skip_;
 }
 
+
+
+std::string BulkCurrent::getTypeStrForName() const
+{
+    return std::string("Bulk_Current");
+}
+
 } 
 } 

--- a/src/core/outputRequest/BulkCurrent.h
+++ b/src/core/outputRequest/BulkCurrent.h
@@ -21,6 +21,8 @@ public:
     math::Constants::CartesianAxis getDir() const;
     math::UInt                     getSkip() const;
 
+    virtual std::string getTypeStrForName() const override;
+
 private:
     math::Constants::CartesianAxis dir_;
     math::UInt                     skip_;
@@ -28,4 +30,3 @@ private:
 
 } 
 } 
-

--- a/src/core/outputRequest/FarField.cpp
+++ b/src/core/outputRequest/FarField.cpp
@@ -18,5 +18,10 @@ FarField::FarField(const Domain& domain,
     stepPhi = sPhi;
 }
 
+    std::string FarField::getTypeStrForName() const
+    {
+        return std::string("Far_Field");
+    }
+        
 } 
 } 

--- a/src/core/outputRequest/FarField.h
+++ b/src/core/outputRequest/FarField.h
@@ -19,10 +19,11 @@ public:
         return std::make_unique<FarField>(*this);
     }
 
+    virtual std::string getTypeStrForName() const override;
+
     math::Real initialTheta, finalTheta, stepTheta;
     math::Real initialPhi, finalPhi, stepPhi;
 };
 
 } 
 } 
-

--- a/src/core/outputRequest/OnPoint.cpp
+++ b/src/core/outputRequest/OnPoint.cpp
@@ -12,5 +12,9 @@ namespace outputRequest {
         : OutputRequest(outputType, name, domain, elem)
     {}
 
+    std::string OnPoint::getTypeStrForName() const
+    {
+        return std::string("On_Point");
+    }
 } 
 } 

--- a/src/core/outputRequest/OnPoint.h
+++ b/src/core/outputRequest/OnPoint.h
@@ -17,6 +17,7 @@ namespace outputRequest {
         std::unique_ptr<OutputRequest> clone() const override {
             return std::make_unique<OnPoint>(*this);
         }
+        virtual std::string getTypeStrForName() const override;
     };
 
 } 

--- a/src/core/outputRequest/OutputRequest.cpp
+++ b/src/core/outputRequest/OutputRequest.cpp
@@ -42,5 +42,11 @@ std::string OutputRequest::getTypeStr() const
     }
 }
 
+
+std::string OutputRequest::getTypeStrForName() const
+{
+    return std::string();
+}
+
 } 
-} 
+}

--- a/src/core/outputRequest/OutputRequest.h
+++ b/src/core/outputRequest/OutputRequest.h
@@ -52,6 +52,8 @@ public:
     void setTarget(const Target& target) { target_ = target; }
 
     std::string getTypeStr() const;
+    virtual std::string getTypeStrForName() const;
+
    
 private:
     std::string name_;
@@ -73,5 +75,4 @@ public:
 
 } 
 } 
-} 
-
+}

--- a/src/exporters/ExporterVTK.cpp
+++ b/src/exporters/ExporterVTK.cpp
@@ -126,7 +126,7 @@ void ExporterVTK::writeMesh_(const UnstructuredProblemDescription& smb)
     for (const auto& oRq : oRqs) {
         writeFile_(
             mesh->elems().atIds(oRq->getTarget()),
-            makeValid_(preName + "OutRq_" + oRq->getName()),
+            makeValid_(preName + "OutRq_" + oRq->getTypeStrForName() + "_" + oRq->getName()),
             outFile,
             part
         );
@@ -308,4 +308,4 @@ std::string ExporterVTK::makeValid_(const std::string& allocator) {
 }
 
 }
-} 
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,3 +2,4 @@ cmake_minimum_required(VERSION 3.0)
 
 add_subdirectory(core)
 add_subdirectory(parsers)
+add_subdirectory(exporters)

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(opensemba_core_tests
     "math/util/RealTest.cpp"
     "math/vector/CartesianVectorTest.cpp"
     "model/ModelTest.cpp"
+    "outputRequest/OutputRequestTest.cpp"
     "physicalModel/multiport/MultiWirePortTest.cpp"
     "physicalModel/multiport/RLCTest.cpp"
     "physicalModel/volume/ClassicTest.cpp"

--- a/test/core/outputRequest/OutputRequestTest.cpp
+++ b/test/core/outputRequest/OutputRequestTest.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <gmock/gmock-matchers.h>
+
+#include "core/outputRequest/BulkCurrent.h"
+#include "core/outputRequest/Domain.h"
+#include "core/outputRequest/FarField.h"
+#include "core/outputRequest/OnLayer.h"
+#include "core/outputRequest/OnLine.h"
+#include "core/outputRequest/OnPoint.h"
+#include "core/outputRequest/OnSurface.h"
+#include "core/outputRequest/OutputRequest.h"
+
+using namespace semba;
+using namespace outputRequest;
+using namespace geometry;
+
+class OutputRequestTest : public ::testing::Test {
+
+    void SetUp() {}
+
+    void TearDown() {}
+
+};
+
+TEST_F(OutputRequestTest, getOutputRequestTypeStrForName) {
+    {
+        Domain domain;
+        OutputRequest::Target target;
+        OnLayer onLayer(OutputRequest::Type::magnetic, domain, "onLayer", target);
+        OnLine onLine(OutputRequest::Type::magnetic, domain, "onLayer", target);
+        OnSurface onSurface(OutputRequest::Type::magnetic, domain, "onLayer", target);
+
+        FarField farField(domain, "FarField", target, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        OnPoint onPoint(OutputRequest::Type::magnetic, domain, "onPoint", target);
+        BulkCurrent bulk(domain, "bulkCurrent", target, math::Constants::CartesianAxis::x, 0);
+
+        EXPECT_THAT(onLayer.getTypeStrForName(), ::testing::StrEq(std::string()));
+        EXPECT_THAT(onLine.getTypeStrForName(), ::testing::StrEq(std::string()));
+        EXPECT_THAT(onSurface.getTypeStrForName(), ::testing::StrEq(std::string()));
+
+        EXPECT_THAT(farField.getTypeStrForName(), ::testing::StrEq(std::string("Far_Field")));
+        EXPECT_THAT(onPoint.getTypeStrForName(), ::testing::StrEq(std::string("On_Point")));
+        EXPECT_THAT(bulk.getTypeStrForName(), ::testing::StrEq(std::string("Bulk_Current")));
+    }
+}

--- a/test/exporters/CMakeLists.txt
+++ b/test/exporters/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+
+message(STATUS "Configuring build system for opensemba_exporters_tests.")
+
+find_package(GTest CONFIG REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
+include(GoogleTest)
+
+add_executable(opensemba_exporters_tests 
+    "ExporterVTKTest.cpp"
+)
+
+target_link_libraries(opensemba_exporters_tests 
+    opensemba_exporters
+    GTest::gtest     
+    GTest::gtest_main
+)
+
+
+gtest_add_tests(
+    TARGET opensemba_exporters_tests
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)
+gtest_discover_tests(
+    opensemba_exporters_tests
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)

--- a/test/exporters/ExporterVTKTest.cpp
+++ b/test/exporters/ExporterVTKTest.cpp
@@ -1,0 +1,109 @@
+
+#include <gtest/gtest.h>
+
+#include "core/geometry/element/Node.h"
+#include "core/geometry/element/Line2.h"
+#include "core/geometry/element/Hexahedron8.h"
+#include "core/outputRequest/BulkCurrent.h"
+#include "core/outputRequest/FarField.h"
+#include "core/outputRequest/OnLine.h"
+#include "core/outputRequest/OnPoint.h"
+#include "core/outputRequest/OutputRequest.h"
+#include "exporters/ExporterVTK.h"
+#include <nlohmann/json.hpp>
+
+using namespace semba::math::Constants;
+
+
+using namespace std;
+using namespace semba;
+using namespace outputRequest;
+using namespace geometry;
+
+class ExporterVTKTest : public ::testing::Test {
+
+    void SetUp(){
+   
+    }
+
+    void TearDown() {}
+
+protected:
+    ExporterVTKTest() {
+        resultFilesFolder_ = "./test/exporters/resultFiles/";
+    }
+
+    string resultFilesFolder_;
+	string getCaseName(const string project) const {
+		return resultFilesFolder_ + project;
+	}
+
+    string getVTKPath(const string project) {
+        return getCaseName(project) + "/" + project + ".vtk";
+    }
+
+    string getVtu(const string project, const string name, OutputRequest * request) {
+        return getVTKPath(project) + "/" + "OutRq_" + request->getTypeStrForName() + "_" + name + ".vtu";
+    }
+
+    void cleanFolders(const string path) const {
+        if (filesystem::exists(path))
+            filesystem::remove_all(path);
+        
+    }
+
+    void createFolder(const string path) const {
+        filesystem::create_directory(path);
+    }
+};
+
+TEST_F(ExporterVTKTest, exportProbes)
+{
+    string projectName = "exportProbes";
+    string bulkProbeName = "probe1";
+    string pointProbeName = "probe2";
+    string farFieldName = "probe3";
+    string lineProbeName = "probe4";
+
+    cleanFolders(getCaseName(projectName));
+    createFolder(getCaseName(projectName));
+
+    UnstructuredProblemDescription unstructured;
+
+    map<string, double> dictionary;
+    dictionary["geometryScalingFactor"] = 0.0;
+    unstructured.analysis = nlohmann::json(dictionary);
+
+    unstructured.model.mesh.coords().addAndAssignId(make_unique<CoordR3>(math::CVecI3(0, 0, 0)));
+    unstructured.model.mesh.coords().addAndAssignId(make_unique<CoordR3>(math::CVecI3(1, 0, 0)));
+    unstructured.model.mesh.coords().addAndAssignId(make_unique<CoordR3>(math::CVecI3(1, 1, 0)));
+    unstructured.model.mesh.coords().addAndAssignId(make_unique<CoordR3>(math::CVecI3(0, 1, 0)));
+    unstructured.model.mesh.coords().addAndAssignId(make_unique<CoordR3>(math::CVecI3(0, 0, 1)));
+    unstructured.model.mesh.coords().addAndAssignId(make_unique<CoordR3>(math::CVecI3(1, 0, 1)));
+    unstructured.model.mesh.coords().addAndAssignId(make_unique<CoordR3>(math::CVecI3(1, 1, 1)));
+    unstructured.model.mesh.coords().addAndAssignId(make_unique<CoordR3>(math::CVecI3(0, 1, 1)));
+
+    auto& bulkCoords = unstructured.model.mesh.coords().get();
+    vector<CoordR3*> pointCoord{ unstructured.model.mesh.coords().atId(CoordId(1)) };
+    auto& lineCoords{ unstructured.model.mesh.coords().atIds(vector<CoordId>{CoordId(2), CoordId(3)})};
+
+    NodR node;
+    node.setV(0, pointCoord[0]);
+
+    unstructured.model.mesh.elems().addAndAssignId(make_unique<HexR8>(ElemId(1), bulkCoords));
+    unstructured.model.mesh.elems().addAndAssignId(make_unique<NodR>(node));
+    unstructured.model.mesh.elems().addAndAssignId(make_unique<LinR2>(ElemId(3), lineCoords));
+    
+
+    unstructured.outputRequests.addAndAssignId(make_unique<BulkCurrent>(Domain(), bulkProbeName, std::vector<ElemId>{ElemId(1)}, CartesianAxis::x, 5));
+    unstructured.outputRequests.addAndAssignId(make_unique<OnPoint>(OutputRequest::Type::current, Domain(), pointProbeName, std::vector<ElemId>{ElemId(2)}));
+    unstructured.outputRequests.addAndAssignId(make_unique<FarField>(Domain(), farFieldName, std::vector<ElemId>{ElemId(2)}, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    unstructured.outputRequests.addAndAssignId(make_unique<OnLine>(OutputRequest::Type::current, Domain(), lineProbeName, std::vector<ElemId>{ElemId(3)}));
+
+    exporters::ExporterVTK exporter = exporters::ExporterVTK(unstructured, getCaseName(projectName) + "/" + projectName);
+    
+    EXPECT_TRUE(filesystem::exists(getVtu(projectName, bulkProbeName, unstructured.outputRequests.atId(Id(1)))));
+    EXPECT_TRUE(filesystem::exists(getVtu(projectName, pointProbeName, unstructured.outputRequests.atId(Id(2)))));
+    EXPECT_TRUE(filesystem::exists(getVtu(projectName, farFieldName, unstructured.outputRequests.atId(Id(3)))));
+    EXPECT_TRUE(filesystem::exists(getVtu(projectName, lineProbeName, unstructured.outputRequests.atId(Id(4)))));
+}


### PR DESCRIPTION
Change the names of VTK files to make them have their Probe Types in their names